### PR TITLE
Treat pytest warnings as errors

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -10,4 +10,4 @@ if __name__ == "__main__":
     root = abspath(dirname(__file__))
     os.chdir(root)
 
-    subprocess.check_call([sys.executable, "-m", "py.test"])
+    subprocess.check_call([sys.executable, "-m", "py.test", "-Werror"])


### PR DESCRIPTION
Note: This will cause tests to fail as they should.