### PR TITLE
Fix entry.value for string arrays

### DIFF
--- a/_pyntcore/src/py2value.cpp
+++ b/_pyntcore/src/py2value.cpp
@@ -5,7 +5,7 @@
 
 // type casters
 #include <pybind11/stl.h>
-
+#include <wpi_span_type_caster.h>
 
 
 

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -9,6 +9,7 @@ def test_entry_string(nt):
     e.setString("value")
     assert e.getString(None) == "value"
     assert e.getValue().value() == "value"
+    assert e.value == "value"
     e.delete()
     assert e.getString(None) is None
     e.setString("value")
@@ -21,6 +22,7 @@ def test_entry_string_array(nt):
     e.setStringArray(["value"])
     assert e.getStringArray(None) == ["value"]
     assert e.getValue().value() == ["value"]
+    assert e.value == ["value"]
     e.delete()
     assert e.getStringArray(None) is None
     e.setStringArray(["value"])

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -3,15 +3,28 @@
 #
 
 
-def test_entry_value(nt):
+def test_entry_string(nt):
     e = nt.getEntry("/k1")
     assert e.getString(None) is None
     e.setString("value")
     assert e.getString(None) == "value"
+    assert e.getValue().value() == "value"
     e.delete()
     assert e.getString(None) is None
     e.setString("value")
     assert e.getString(None) == "value"
+
+
+def test_entry_string_array(nt):
+    e = nt.getEntry("/k1")
+    assert e.getStringArray(None) is None
+    e.setStringArray(["value"])
+    assert e.getStringArray(None) == ["value"]
+    assert e.getValue().value() == ["value"]
+    e.delete()
+    assert e.getStringArray(None) is None
+    e.setStringArray(["value"])
+    assert e.getStringArray(None) == ["value"]
 
 
 def test_entry_persistence(nt):


### PR DESCRIPTION
This fixes a `TypeError` when attempting to use a `magicbot.StateMachine`:

```pytb
TypeError: Unregistered type : wpi::span<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, 18446744073709551615ul>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "~/.local/share/virtualenvs/rpy-2022/lib/python3.9/site-packages/wpilib/_impl/start.py", line 124, in _start
    self.robot.startCompetition()
  File "~/dev/frc/robotpy/robotpy-wpilib-utilities/magicbot/magicrobot.py", line 353, in startCompetition
    self.robotInit()
  File "~/dev/frc/robotpy/robotpy-wpilib-utilities/magicbot/magicrobot.py", line 104, in robotInit
    self._create_components()
  File "~/dev/frc/robotpy/robotpy-wpilib-utilities/magicbot/magicrobot.py", line 630, in _create_components
    self._feedbacks += collect_feedbacks(component, cname, "components")
  File "~/dev/frc/robotpy/robotpy-wpilib-utilities/magicbot/magic_tunable.py", line 228, in collect_feedbacks
    for name, method in inspect.getmembers(component, inspect.ismethod):
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/inspect.py", line 351, in getmembers
    value = getattr(object, key)
  File "~/dev/frc/robotpy/robotpy-wpilib-utilities/magicbot/magic_tunable.py", line 99, in __get__
    return instance._tunables[self].value
TypeError: Unable to convert function return value to a Python type! The signature was
	(arg0: _pyntcore._ntcore.NetworkTableEntry) -> object