### PR TITLE
Add ValueT union type

### DIFF
--- a/ntcore/types.py
+++ b/ntcore/types.py
@@ -1,0 +1,13 @@
+from typing import Sequence, Union
+
+ValueT = Union[
+    bool,
+    int,
+    float,
+    str,
+    bytes,
+    Sequence[bool],
+    Sequence[int],
+    Sequence[float],
+    Sequence[str],
+]


### PR DESCRIPTION
This provides a single source of truth for what types `NetworkTableEntry.setValue` takes.